### PR TITLE
Frontend Layout and Template

### DIFF
--- a/app/code/community/Staempfli/ProductAttachment/Helper/Data.php
+++ b/app/code/community/Staempfli/ProductAttachment/Helper/Data.php
@@ -178,4 +178,31 @@ class Staempfli_ProductAttachment_Helper_Data extends Mage_Core_Helper_Abstract
         $clean      = preg_replace("/[^a-zA-Z0-9]/", "", $filename) . '.' . $extension;
         return $clean;
     }
+    /**
+     * @param $name
+     * @param $product_id
+     * @param $store_id
+     * @return string
+     */
+    public function getFilePath($name, $product_id, $store_id = false)
+    {
+        $path = Mage::helper('staempfli_productattachment')->getUploadDir();
+
+        if($store_id !== false) {
+            $path = $path . DS . $store_id;
+        }
+
+        if($product_id) {
+            $path = $path . DS . $product_id;
+        }
+
+        if(!is_dir($path)) {
+            if(!mkdir($path, 0777, true)) {
+                Mage::log('Unable to create directory: ' . $path, Zend_log::ERR, Staempfli_ProductAttachment_Helper_Data::LOG_FILE);
+                return false;
+            }
+        }
+
+        return $path . DS . $name;
+    }
 }

--- a/app/code/community/Staempfli/ProductAttachment/etc/config.xml
+++ b/app/code/community/Staempfli/ProductAttachment/etc/config.xml
@@ -76,4 +76,13 @@
             </updates>
         </layout>
     </adminhtml>
+    <frontend>
+        <layout>
+            <updates>
+                <staempfli_productattachment>
+                    <file>productattachment.xml</file>
+                </staempfli_productattachment>
+            </updates>
+        </layout>
+    </frontend>
 </config>

--- a/app/design/frontend/base/default/layout/productattachment.xml
+++ b/app/design/frontend/base/default/layout/productattachment.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<layout version="0.1.0">
+    <catalog_product_view>
+        <reference name="product.info">
+            <block type="catalog/product_view" name="product.mediathek" as="mediathek" template="productattachment/mediathek.phtml">
+                <action method="addToParentGroup"><group>detailed_info</group></action>
+                <action method="setTitle" translate="value"><value>Mediathek</value></action>
+            </block>
+
+        </reference>
+    </catalog_product_view>
+</layout>
+

--- a/app/design/frontend/base/default/template/productattachment/mediathek.phtml
+++ b/app/design/frontend/base/default/template/productattachment/mediathek.phtml
@@ -1,0 +1,16 @@
+<?php
+if (($files = Mage::getModel('staempfli_productattachment/file')->getFilesByProductId($this->getProduct()->getId(), Mage::app()->getStore()->getStoreId(), false, true)->getData()) && count($files) > 0):
+    $helper = $this->helper('staempfli_productattachment');
+    $dir = Mage::getBaseUrl('media').$helper::UPLOAD_DIR;
+    ?>
+<li class="tab_list_element">
+    <!-- <a id="mediathek" class="headline active"><?php echo $this->__('Mediathek') ?></a> -->
+    <div id="tab-mediathek" class="tabs_content">
+        <?php foreach ($files as $file): ?>
+            <div class="mediathek">
+                <i class="fa fa-file-<?=$file['type']; ?>-o fa-2x"></i> <a href="<?= $dir.DS.$file['path']; ?>"><?= $file['description'];?></a>
+            </div>
+        <?php endforeach; ?>
+    </div>
+</li>
+<?php endif; ?>

--- a/modman
+++ b/modman
@@ -2,5 +2,7 @@ app/code/community/Staempfli/ProductAttachment                              app/
 app/etc/modules/Staempfli_ProductAttachment.xml                             app/etc/modules/Staempfli_ProductAttachment.xml
 app/design/adminhtml/default/default/template/staempfli/productattachment   app/design/adminhtml/default/default/template/staempfli/productattachment
 app/design/adminhtml/default/default/layout/staempfli/productattachment.xml app/design/adminhtml/default/default/layout/staempfli/productattachment.xml
+app/design/frontend/base/default/layout/productattachment.xml               app/design/frontend/base/default/layout/productattachment.xml
+app/design/frontend/base/default/template/productattachment               app/design/frontend/base/default/template/productattachment
 skin/adminhtml/default/default/staempfli/css/productattachment.css          skin/adminhtml/default/default/staempfli/css/productattachment.css
 app/locale/de_DE/Staempfli_ProductAttachment.csv                            app/locale/de_DE/Staempfli_ProductAttachment.csv


### PR DESCRIPTION
As I said i will provide a frontend template so this extension is more usable without doing it all by yourself. 
Because we use `product.info detailed_info` in the XML-file it will be correctly rendered in a standard template (base/default and rwd/default).
