### PR TITLE
Made listAction parameters optionals

### DIFF
--- a/app/code/community/Staempfli/ProductAttachment/controllers/Adminhtml/ProductattachmentController.php
+++ b/app/code/community/Staempfli/ProductAttachment/controllers/Adminhtml/ProductattachmentController.php
@@ -92,7 +92,7 @@ class Staempfli_ProductAttachment_Adminhtml_ProductattachmentController extends 
      * @param $product_id
      * @param $store_id
      */
-    public function listAction($product_id, $store_id)
+    public function listAction($product_id = null, $store_id = null)
     {
         $filesArray     = array();
         $sessionFormKey = Mage::getSingleton('core/session')->getFormKey();


### PR DESCRIPTION
When the action is dispatched the parameters aren't set, this throw a warning that block ajax call when developerMode is active.
